### PR TITLE
Make check for "nothing to commit" state looser.

### DIFF
--- a/action_plugins/etckeeper-post-task.py
+++ b/action_plugins/etckeeper-post-task.py
@@ -17,7 +17,7 @@ def run_etckeeper(self, msg):
     result = self._low_level_execute_command('etckeeper commit "%s"' % msg)
 
     # In case of no changes the command will fail, but ignore that
-    if (result['rc'] == 1) and ('nothing to commit, working tree clean' in result['stdout']):
+    if (result['rc'] == 1) and ('nothing to commit' in result['stdout']):
         result['rc'] = 0
 
     # If etckeeper is not installed, do not treat that as an error.

--- a/action_plugins/etckeeper-pre-task.py
+++ b/action_plugins/etckeeper-pre-task.py
@@ -17,7 +17,7 @@ def run_etckeeper(self, msg):
     result = self._low_level_execute_command('etckeeper commit "%s"' % msg)
 
     # In case of no changes the command will fail, but ignore that
-    if (result['rc'] == 1) and ('nothing to commit, working tree clean' in result['stdout']):
+    if (result['rc'] == 1) and ('nothing to commit' in result['stdout']):
         result['rc'] = 0
 
     # If etckeeper is not installed, do not treat that as an error.


### PR DESCRIPTION
On older versions of etckeeper (CentOS7 EPEL7's version), the output uses "directory" instead of "tree". This way it works with either.