### PR TITLE
Add an additional etckeeper action that allows for setting custom msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ or
 [user](https://docs.ansible.com/ansible/latest/modules/user_module.html)
 are not committed automatically.
 
-With the two actions `etckeeper-pre-task` and `etckeeper-post-task` you can
+With the three actions `etckeeper-pre-task`, `etckeeper-commit-task`, and `etckeeper-post-task` you can
 make sure that any changes in `/etc` triggered by an ansible task are commited.
 
 
@@ -57,6 +57,17 @@ with commit message `saving uncommitted changes in /etc prior to ansible task ru
 
 If the user were removed, that change would be checked in with a commit with message
 `saving uncommitted changes in /etc prior to ansible task run`.
+
+To set a custom message on a commit:
+```yaml
+---
+- hosts: all
+  gather_facts: no
+  tasks:
+    - etckeeper-commit-task:
+      msg: Etckeeper commit in role_name taskfile before some_change
+```
+
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ or
 [user](https://docs.ansible.com/ansible/latest/modules/user_module.html)
 are not committed automatically.
 
-With the three actions `etckeeper-pre-task`, `etckeeper-commit-task`, and `etckeeper-post-task` you can
-make sure that any changes in `/etc` triggered by an ansible task are commited.
+With the three actions `etckeeper-pre-task`, `etckeeper-commit-task`, and
+`etckeeper-post-task` you can make sure that any changes in `/etc` triggered
+by an ansible task are commited.
 
 
 ## Example Playbook

--- a/action_plugins/etckeeper-commit-task.py
+++ b/action_plugins/etckeeper-commit-task.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Håkon Løvdal <kode@denkule.no>
+# GNU General Public License v3.0+ (see gpl.txt, https://tldrlegal.com/l/gpl-3.0 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# TODO: Find a way to share this between the files. Failed attempts:
+#from lib_etckeeper import run_etckeeper   # ERROR! Unexpected Exception, this is probably a bug: No module named 'lib_etckeeper'
+#from .lib_etckeeper import run_etckeeper  # ERROR! Unexpected Exception, this is probably a bug: No module named 'ansible.plugins.action.lib_etckeeper'
+#from . import lib_etckeeper               # ERROR! Unexpected Exception, this is probably a bug: cannot import name 'lib_etckeeper' from 'ansible.plugins.action' (/usr/lib/python3.7/site-packages/ansible/plugins/action/__init__.py)
+
+import os
+
+def run_etckeeper(self, msg):
+    # Make sure we are not parsing localized text
+    os.environ["LC_ALL"] = "C"
+
+    result = self._low_level_execute_command('etckeeper commit "%s"' % msg)
+
+    # In case of no changes the command will fail, but ignore that
+    if (result['rc'] == 1) and ('nothing to commit, working tree clean' in result['stdout']):
+        result['rc'] = 0
+
+    # If etckeeper is not installed, do not treat that as an error.
+    # Return code 127 is established behaviour for command not found. http://www.tldp.org/LDP/abs/html/exitcodes.html, https://stackoverflow.com/q/1763156/23118
+    if (result['rc'] == 127) and ('command not found' in result['stdout']):
+        result['rc'] = 0
+
+    return result
+
+
+from ansible.plugins.action import ActionBase
+
+class ActionModule(ActionBase):
+
+    TRANSFERS_FILES = False
+
+    def run(self, tmp=None, task_vars=None):
+        
+        validation_result, new_module_args = self.validate_argument_spec(
+            argument_spec={
+                'msg': {'type': 'raw', 'default': 'saving uncommitted changes in /etc within ansible run'},
+            },
+        )
+
+        msg = new_module_args['msg']
+        
+        result = run_etckeeper(self, msg)
+        return result

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -7,15 +7,36 @@
 
     - etckeeper-pre-task:
 
-    - name: "Task that modifies test file in /etc"
+    - name: "Task that modifies test file in /etc 1"
       lineinfile:
         path: "/etc/eliftset"
-        line: 'test line'
+        line: 'test line 1'
         state: present
-      register: file_modification_result
+      register: file_modification_result1
+
+    - etckeeper-commit-task:
+      when: file_modification_result1.changed
+
+    - name: "Task that modifies test file in /etc 2"
+      lineinfile:
+        path: "/etc/eliftset"
+        line: 'test line 2'
+        state: present
+      register: file_modification_result2
+
+    - etckeeper-commit-task:
+        msg: Etckeeper commit with custom message after adding test line 2 to eliftset
+      when: file_modification_result2.changed
+
+    - name: "Task that modifies test file in /etc 3"
+      lineinfile:
+        path: "/etc/eliftset"
+        line: 'test line 3'
+        state: present
+      register: file_modification_result3
 
     - etckeeper-post-task:
-      when: file_modification_result.changed
+      when: file_modification_result1.changed
 
     - name: "Cleanup"
       file:


### PR DESCRIPTION
To set a custom message on a commit:
```yaml
---
- hosts: all
  gather_facts: no
  tasks:
    - etckeeper-commit-task:
      msg: Etckeeper commit in role_name taskfile before some_change
```
